### PR TITLE
Update nuget packages

### DIFF
--- a/src/sharp-bunny/Configuration/Config.cs
+++ b/src/sharp-bunny/Configuration/Config.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System;
 using System.Text;
 using Newtonsoft.Json;
 
@@ -14,9 +14,9 @@ namespace SharpBunny
             return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(msg));
         }
 
-        internal static T Deserialize<T>(byte[] arg)
+        internal static T Deserialize<T>(ReadOnlyMemory<byte> arg)
         {
-            string decoded = Encoding.UTF8.GetString(arg);
+            string decoded = Encoding.UTF8.GetString(arg.Span);
             return JsonConvert.DeserializeObject<T>(decoded);
         }
     }

--- a/src/sharp-bunny/Consume/DeclareResponder.cs
+++ b/src/sharp-bunny/Consume/DeclareResponder.cs
@@ -22,7 +22,7 @@ namespace SharpBunny.Consume
         #region mutable fields
         private bool _useTempQueue;
         private bool _useUniqueChannel;
-        private Func<byte[], TRequest> _deserialize;
+        private Func<ReadOnlyMemory<byte>, TRequest> _deserialize;
         private Func<TResponse, byte[]> _serialize;
         private Func<TRequest, Task<TResponse>> _respond;
         #endregion
@@ -99,7 +99,7 @@ namespace SharpBunny.Consume
             return this;
         }
 
-        public IRespond<TRequest, TResponse> WithDeserialize(Func<byte[], TRequest> deserialize)
+        public IRespond<TRequest, TResponse> WithDeserialize(Func<ReadOnlyMemory<byte>, TRequest> deserialize)
         {
             _deserialize = deserialize;
             return this;

--- a/src/sharp-bunny/IConsume.cs
+++ b/src/sharp-bunny/IConsume.cs
@@ -28,7 +28,7 @@ namespace SharpBunny
         ///<summary>
         /// Specify your own Desiarilze function for deserializing the message. Default is Json.
         ///</summary>
-        IConsume<TMsg> DeserializeMessage(Func<byte[], TMsg> deserialize);
+        IConsume<TMsg> DeserializeMessage(Func<ReadOnlyMemory<byte>, TMsg> deserialize);
 
         ///<summary>
         /// Starts consuming from the specified or forceDeclared Queue

--- a/src/sharp-bunny/IRequest.cs
+++ b/src/sharp-bunny/IRequest.cs
@@ -33,7 +33,7 @@ namespace SharpBunny
         ///<summary>
         /// Specify a Deserialize function
         ///</summary>
-        IRequest<TRequest, TResponse> DeserializeResponse(Func<byte[], TResponse> deserialize);
+        IRequest<TRequest, TResponse> DeserializeResponse(Func<ReadOnlyMemory<byte>, TResponse> deserialize);
         ///<summary>
         /// Force a Queue declare before sending.
         ///</summary>

--- a/src/sharp-bunny/IRespond.cs
+++ b/src/sharp-bunny/IRespond.cs
@@ -21,7 +21,7 @@ namespace SharpBunny
         ///<summary>
         /// Override Deserialize method
         ///</summary>
-        IRespond<TRequest, TResponse> WithDeserialize(Func<byte[], TRequest> deserialize);
+        IRespond<TRequest, TResponse> WithDeserialize(Func<ReadOnlyMemory<byte>, TRequest> deserialize);
         ///<summary>
         /// If applied, uses a new channel for each Response (publish with reply_to tag)
         ///</summary>

--- a/src/sharp-bunny/Publish/DeclareRequest.cs
+++ b/src/sharp-bunny/Publish/DeclareRequest.cs
@@ -21,7 +21,7 @@ namespace SharpBunny.Publish
 
         #region mutable fields
         private int _timeOut = 1500;
-        private Func<byte[], TResponse> _deserialize;
+        private Func<ReadOnlyMemory<byte>, TResponse> _deserialize;
         private Func<TRequest, byte[]> _serialize;
         private bool _useTempQueue;
         private bool _useUniqueChannel;
@@ -200,7 +200,7 @@ namespace SharpBunny.Publish
             return this;
         }
 
-        public IRequest<TRequest, TResponse> DeserializeResponse(Func<byte[], TResponse> deserialize)
+        public IRequest<TRequest, TResponse> DeserializeResponse(Func<ReadOnlyMemory<byte>, TResponse> deserialize)
         {
             _deserialize = deserialize;
             return this;

--- a/src/sharp-bunny/sharp-bunny.csproj
+++ b/src/sharp-bunny/sharp-bunny.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>sharp_bunny</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2"/>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated RabbitMQ.Client to 6.20. Notable changes are:
- this required to change the target to netstandard2.1 for the overload Encoding.UTF8.GetString(ReadOnlySpan<T>)
- byte arrays are now ReadOnlyMemory<byte>
- the ConsumerTag property does not exist directly on the consumer anymore since it can hold multiple ConsumerTags. That's why on Dispose, unregister cancel all Channels belonging to that consumer's tags

On another note, @TimoHeiten could you create a nuget package for this repo?