### PR TITLE
Make deliverytag public

### DIFF
--- a/src/sharp-bunny/Consume/Carrot.cs
+++ b/src/sharp-bunny/Consume/Carrot.cs
@@ -6,17 +6,18 @@ namespace SharpBunny.Consume
 {
     public class Carrot<TMsg> : ICarrot<TMsg>
     {
-        private readonly ulong _deilvered;
         private readonly PermanentChannel _thisChannel;
 
-        public Carrot(TMsg message, ulong deilvered, PermanentChannel thisChannel)
+        public Carrot(TMsg message, ulong deliveryTag, PermanentChannel thisChannel)
         {
             Message = message;
-            _deilvered = deilvered;
+            DeliveryTag = deliveryTag;
             _thisChannel = thisChannel;
         }
 
         public TMsg Message { get; }
+        
+        public ulong DeliveryTag { get; }
 
         public IBasicProperties MessageProperties { get; set; }
 
@@ -26,7 +27,7 @@ namespace SharpBunny.Consume
                 try
                 {
                     await Task.Run(() => 
-                                    _thisChannel.Channel.BasicAck(_deilvered, multiple: false)
+                                    _thisChannel.Channel.BasicAck(DeliveryTag, multiple: false)
                     );
                     result.IsSuccess = true;
                     result.State = OperationState.Acked;
@@ -48,7 +49,7 @@ namespace SharpBunny.Consume
                 try
                 {
                     await Task.Run(() => 
-                                    _thisChannel.Channel.BasicReject(_deilvered, requeue: withRequeue)
+                                    _thisChannel.Channel.BasicReject(DeliveryTag, requeue: withRequeue)
                     );
                     result.IsSuccess = true;
                     result.State = OperationState.Nacked;

--- a/src/sharp-bunny/Consume/Carrot.cs
+++ b/src/sharp-bunny/Consume/Carrot.cs
@@ -6,18 +6,17 @@ namespace SharpBunny.Consume
 {
     public class Carrot<TMsg> : ICarrot<TMsg>
     {
-        private readonly TMsg _message;
         private readonly ulong _deilvered;
         private readonly PermanentChannel _thisChannel;
 
         public Carrot(TMsg message, ulong deilvered, PermanentChannel thisChannel)
         {
-            _message = message;
+            Message = message;
             _deilvered = deilvered;
             _thisChannel = thisChannel;
         }
 
-        public TMsg Message => _message;
+        public TMsg Message { get; }
 
         public IBasicProperties MessageProperties { get; set; }
 

--- a/src/sharp-bunny/Consume/Carrot.cs
+++ b/src/sharp-bunny/Consume/Carrot.cs
@@ -21,13 +21,13 @@ namespace SharpBunny.Consume
 
         public IBasicProperties MessageProperties { get; set; }
 
-        public async Task<OperationResult<TMsg>> SendAckAsync()
+        public async Task<OperationResult<TMsg>> SendAckAsync(bool multiple = false)
             {
                 var result = new OperationResult<TMsg>();
                 try
                 {
                     await Task.Run(() => 
-                                    _thisChannel.Channel.BasicAck(DeliveryTag, multiple: false)
+                                    _thisChannel.Channel.BasicAck(DeliveryTag, multiple: multiple)
                     );
                     result.IsSuccess = true;
                     result.State = OperationState.Acked;
@@ -43,13 +43,13 @@ namespace SharpBunny.Consume
                 return result;
             }
 
-            public async Task<OperationResult<TMsg>> SendNackAsync(bool withRequeue = true)
+            public async Task<OperationResult<TMsg>> SendNackAsync(bool multiple = false, bool withRequeue = true)
             {
                 var result = new OperationResult<TMsg>();
                 try
                 {
                     await Task.Run(() => 
-                                    _thisChannel.Channel.BasicReject(DeliveryTag, requeue: withRequeue)
+                                    _thisChannel.Channel.BasicNack(DeliveryTag, multiple: multiple, requeue: withRequeue)
                     );
                     result.IsSuccess = true;
                     result.State = OperationState.Nacked;

--- a/src/sharp-bunny/IConsume.cs
+++ b/src/sharp-bunny/IConsume.cs
@@ -55,7 +55,7 @@ namespace SharpBunny
         ulong DeliveryTag { get; }
         TMsg Message { get; }
         IBasicProperties MessageProperties { get; }
-        Task<OperationResult<TMsg>> SendAckAsync();
-        Task<OperationResult<TMsg>> SendNackAsync(bool withRequeue = true);
+        Task<OperationResult<TMsg>> SendAckAsync(bool multiple = false);
+        Task<OperationResult<TMsg>> SendNackAsync(bool multiple = false, bool withRequeue = true);
     }
 }

--- a/src/sharp-bunny/IConsume.cs
+++ b/src/sharp-bunny/IConsume.cs
@@ -52,6 +52,7 @@ namespace SharpBunny
     ///</summary>
     public interface ICarrot<TMsg>
     {
+        ulong DeliveryTag { get; }
         TMsg Message { get; }
         IBasicProperties MessageProperties { get; }
         Task<OperationResult<TMsg>> SendAckAsync();

--- a/src/sharp-bunny/IConsume.cs
+++ b/src/sharp-bunny/IConsume.cs
@@ -25,6 +25,17 @@ namespace SharpBunny
         /// Define the consumer as auto acknowledgement for best possible performance, yet least message reliability.
         ///</summary>
         IConsume<TMsg> AsAutoAck(bool autoAck = true);
+
+        ///<summary>
+        /// Define custom behaviour for acknowledging messages. Will automatically turn off auto acknowledgement.
+        ///</summary>
+        IConsume<TMsg> AckBehaviour(Func<ICarrot<TMsg>, Task> ackBehaviour);
+
+        ///<summary>
+        /// Define custom behaviour for rejecting messages when acknowledging failed.
+        ///</summary>
+        IConsume<TMsg> NackBehaviour(Func<ICarrot<TMsg>, Task> nackBehaviour);
+
         ///<summary>
         /// Specify your own Desiarilze function for deserializing the message. Default is Json.
         ///</summary>


### PR DESCRIPTION
Making DeliveryTag publicly accessible is for situations when users want to manually send Acks or Nacks to their channels, for example when declaring a custom callback and direcly interacting with IModel.

In conjunction with this, there might be a need to add custom behaviour when acking/nacking messages like simply returning and dealing with the acking later.